### PR TITLE
Command interpretation update, general cleanup

### DIFF
--- a/sentbot1-discord.py
+++ b/sentbot1-discord.py
@@ -330,7 +330,7 @@ async def on_ready():
 async def on_message(message):
     messageContent = message.content #editable message content block
     commandMode = -1 # determines the command being used. If it is not a command, the mode is -1.
-    prefixes = [".", "!", "$"]
+    prefixes = ["!", "d.", ".", "$"]
     for i in range(0, len(prefixes): #iterate through each item in the prefix group until you hit the one it is (or not) 
         if messageContent.startswith(prefixes[i]):
             commandMode = i # set the command mode
@@ -346,7 +346,7 @@ async def on_message(message):
             await client.send_message(message.author.mention, "FATAL_ERROR:\nDM's ARE UNSUPPORTED")
             # they don't have to be :^) just use the user ID - will work on this
         else:
-            if commandMode == 2:  # admin commands
+            if commandMode == 3:  # admin commands
                 if str(message.author) in admins:
                     if messageContent == "SHUTDOWN":
                         await client.send_message(message.channel, ":wave:")
@@ -358,25 +358,15 @@ async def on_message(message):
                         await client.send_message(message.channel, newStaff + " added to staff list")
                         
                 else:
-                    await client.send_message(message.channel, "FATAL_ERROR:\nUSER-TYPE \"" + str(message.author.mention) + "\" IS NOT AUTHORISED TO ACCESS SERVER ADMINISTRATION COMMANDS")
-                    
-                    
-            elif commandMode == 0:  # normal/staff commands
-                if str(message.author) in admins or str(message.author) in per.staff:
-                    if messageContent == "LIST_WORDS":
-                        stro = "ALL_WORDS\n\n"
-                        for word in per.dictionary:
-                            stro += "(" + str(len(word.prev)) + ") " + word.text + " (" + str(len(word.next)) + ")\n"
-                        await client.send_message(message.channel, stro)
-                        
-                    elif messageContent == "CLEAR_DICTIONARY":
+                    await client.send_message(message.channel, "FATAL_ERROR:\nUSER-TYPE \"" + str(message.author.mention) + "\" IS NOT AUTHORISED TO ACCESS ADMINISTRATION COMMANDS")
+                   
+                   
+            elif commandMode == 2:  # staff commands
+                if str(message.author) in admins or str(message.author) in per.staff:                       
+                    if messageContent == "CLEAR_DICTIONARY":
                         per.dictionary = []
                         await client.send_message(message.channel, "DICTIONARY CLEARED")
-                        
-                    elif messageContent == "DUMP_STATS":
-                        stri = "FULL STAT LIST\n\n"
-                        await client.send_message(message.channel, stri + str(per.stackSize) + "\n" + str(per.deathCount) + "\n" + str(per.iterations) + "\n" + str(per.averaging) + "\n" + str(per.minimumScore) + "\n\n" + str(per.averageSentenceLength))
-                        
+
                     elif messageContent == "CHANNEL_MODE":
                         per.serverMode = False
                         await client.send_message(message.channel, "CHANNEL MODE ACTIVE")     
@@ -386,8 +376,9 @@ async def on_message(message):
                         await client.send_message(message.channel, "SERVER MODE ACTIVE")
                         
                 else:
-                    await client.send_message(message.channel, "FATAL_ERROR:\nUSER-TYPE \"" + str(message.author.mention) + "\" IS NOT AUTHORISED TO ACCESS COMMANDS")
+                    await client.send_message(message.channel, "FATAL_ERROR:\nUSER-TYPE \"" + str(message.author.mention) + "\" IS NOT AUTHORISED TO ACCESS STAFF COMMANDS")
                     
+                   
             elif commandMode == 1:  # debug commands
                 if str(message.author) in admins or str(message.author) in per.staff:
                     if messageContent.startswith("stackSize="):
@@ -408,8 +399,20 @@ async def on_message(message):
                 
                 else:
                     await client.send_message(message.channel, "FATAL_ERROR:\nUSER-TYPE \"" + str(message.author.mention) + "\" IS NOT AUTHORISED TO EXECUTE DEBUG COMMANDS")
+                    
+                   
+            elif commandMode == 0:  # normal commands
+                if messageContent == "LIST_WORDS":
+                    stro = "ALL_WORDS\n\n"
+                    for word in per.dictionary:
+                        stro += "(" + str(len(word.prev)) + ") " + word.text + " (" + str(len(word.next)) + ")\n"
+                    await client.send_message(message.channel, stro)
+
+                elif messageContent == "DUMP_STATS":
+                    stri = "FULL STAT LIST\n\n"
+                    await client.send_message(message.channel, stri + str(per.stackSize) + "\n" + str(per.deathCount) + "\n" + str(per.iterations) + "\n" + str(per.averaging) + "\n" + str(per.minimumScore) + "\n\n" + str(per.averageSentenceLength))
             
-            
+                   
             else:  # standard text
                 await client.send_typing(message.channel)
                 per = determinePersonality(message)

--- a/sentbot1-discord.py
+++ b/sentbot1-discord.py
@@ -308,10 +308,10 @@ def loadDetails():
         exit()
     
     botName = f.readline().strip('\n')
-    token = f.readline().strip('\n')  # if I remember correctly, this auto-reads the next line
+    token = f.readline().strip('\n')  # auto-reads the next line
 
     admins = f.readline().split(',')
-    admins[-1] = admins[-1].strip('\n')
+    admins[-1] = admins[-1].strip('\n')  # strip the newline off the end of the last admin
     
     return botName, token, admins
 
@@ -344,15 +344,15 @@ async def on_message(message):
             return  # do nothing - so i dont have to put it all in if str(message.author) != botName:
         elif per == "dm":  # if it's a DM
             await client.send_message(message.author.mention, "FATAL_ERROR:\nDM's ARE UNSUPPORTED")
-            # they don't have to be :^) just use the user ID
+            # they don't have to be :^) just use the user ID - will work on this
         else:
-            if commandMode == 2:
+            if commandMode == 2:  # admin commands
                 if str(message.author) in admins:
                     if messageContent == "SHUTDOWN":
                         await client.send_message(message.channel, ":wave:")
                         os._exit(1)
                     
-                    elif messageContent.startswith("STAFF_ADD"): # this just makes sure that we don't have '$abababa STAFF_ADD AASASA' adding "STAFF_ADD AASASA" to the staff list 
+                    elif messageContent.startswith("STAFF_ADD"):
                         newStaff = str(messageContent.split(" ", 1)[1])
                         per.staff.append(newStaff)
                         await client.send_message(message.channel, newStaff + " added to staff list")
@@ -361,8 +361,7 @@ async def on_message(message):
                     await client.send_message(message.channel, "FATAL_ERROR:\nUSER-TYPE \"" + str(message.author.mention) + "\" IS NOT AUTHORISED TO ACCESS SERVER ADMINISTRATION COMMANDS")
                     
                     
-            # WHY DO YOU HAVE ORDERING OF 2 -> 0 -> 1 :ANGERY:
-            elif commandMode == 0:
+            elif commandMode == 0:  # normal/staff commands
                 if str(message.author) in admins or str(message.author) in per.staff:
                     if messageContent == "LIST_WORDS":
                         stro = "ALL_WORDS\n\n"
@@ -389,21 +388,21 @@ async def on_message(message):
                 else:
                     await client.send_message(message.channel, "FATAL_ERROR:\nUSER-TYPE \"" + str(message.author.mention) + "\" IS NOT AUTHORISED TO ACCESS COMMANDS")
                     
-            elif commandMode == 1:
+            elif commandMode == 1:  # debug commands
                 if str(message.author) in admins or str(message.author) in per.staff:
-                    if "stackSize=" in messageContent:
+                    if messageContent.startswith("stackSize="):
                         per.stackSize = int(messageContent.split(" ")[1])
                         await client.send_message(message.channel, "STACK_SIZE CHANGED TO " + str(per.stackSize))
-                    if "deathCount=" in messageContent:
+                    if messageContent.startswith("deathCount="):
                         per.deathCount = int(messageContent.split(" ")[1])
                         await client.send_message(message.channel, "DEATH_COUNT CHANGED TO " + str(per.deathCount))
-                    if "iterations=" in messageContent:
+                    if messageContent.startswith("iterations="):
                         per.iterations = int(messageContent.split(" ")[1])
                         await client.send_message(message.channel, "ITERATIONS CHANGED TO " + str(per.iterations))
-                    if "averaging=" in messageContent:
+                    if messageContent.startswith("averaging="):
                         per.averaging = messageContent.split(" ")[1] == "true"
                         await client.send_message(message.channel, "FLAG _AVERAGING CHANGED TO " + str(per.averaging))
-                    if "minimumScore=" in messageContent:
+                    if messageContent.startswith("minimumScore="):
                         per.minimumScore = int(messageContent.split(" ")[1])
                         await client.send_message(message.channel, "minimum_SCORE CHANGED TO " + str(per.minimumScore))
                 
@@ -427,6 +426,5 @@ async def on_message(message):
     except:
         print("FATAL_ERROR:\nUNKNOWN")
 
-#botName, token, admins = loadDetails()  # this should fetch all the details #you don't need this <- -satanicbanana
         
 client.run(token)

--- a/sentbot1-discord.py
+++ b/sentbot1-discord.py
@@ -331,7 +331,7 @@ async def on_message(message):
     messageContent = message.content #editable message content block
     commandMode = -1 # determines the command being used. If it is not a command, the mode is -1.
     prefixes = ["!", "d.", ".", "$"]
-    for i in range(0, len(prefixes): #iterate through each item in the prefix group until you hit the one it is (or not) 
+    for i in range(0, len(prefixes)): #iterate through each item in the prefix group until you hit the one it is (or not) 
         if messageContent.startswith(prefixes[i]):
             commandMode = i # set the command mode
             messageContent = messageContent.lstrip(prefixes[i]) # remove the command prefix from the command
@@ -430,4 +430,6 @@ async def on_message(message):
         print("FATAL_ERROR:\nUNKNOWN")
 
         
+botName, token, admins = loadDetails()  # this is needed - for the token
+
 client.run(token)


### PR DESCRIPTION
Command interpretation replaced with a loop for the eventual full move to command interpretation loop (?). Small edit made to the way message content is interpreted, abstracting it into a secondary, editable string in order to facilitate manipulation of said string in commands. (this change was not tested, test it before you push it thanks)